### PR TITLE
Hotfix: Update getProgramByName method 

### DIFF
--- a/src/pim/PIMAdapter.php
+++ b/src/pim/PIMAdapter.php
@@ -79,7 +79,9 @@ class PIMAdapter extends Adapter {
             $query
         );
 
-        return $entries;
+        $entries_array = mapEntriesToModel($this->program_content_type, $entries);
+
+        return $entries_array;
     }
 
     /**


### PR DESCRIPTION
Update `getProgramByName` to return `$entries_array` and not `$entries ResourceArray`.