### PR TITLE
Update deadlineTable output to support styling for table header columns

### DIFF
--- a/src/PIM/Helpers/transformDeadlinesToTable.php
+++ b/src/PIM/Helpers/transformDeadlinesToTable.php
@@ -5,7 +5,7 @@ namespace Northeastern\PIMFIMAdapter\PIM\Helpers;
 use DOMDocument;
 
 function transformDeadlinesToTable($deadline_json) {
-    $dom = new DOMDocument('5.0', 'utf-8');
+    $dom = new DOMDocument('1.0', 'utf-8');
 
     
     if (is_null($deadline_json) || empty($deadline_json) || !is_array($deadline_json)) {
@@ -44,13 +44,12 @@ function transformDeadlinesToTable($deadline_json) {
         
         // Table Headers
         foreach ($deadline['headers'] as $thead_th) {
-            if (!empty($thead_th)) {
                 $td = $dom->createElement('td');
+                $td->setAttribute('colspan', 1);
                 $td = $thead_tr->appendChild($td);
                 
                 $th = $dom->createTextNode($thead_th);
                 $th = $td->appendChild($th);
-            }
         }
 
         // Table Items/Values


### PR DESCRIPTION
See [Issue 11](https://github.com/ITS-Digital-Technology/pim-fim-adapter/issues/11) for details.

Notes:

1) Changed version on DOMDocument to "1.0" as it's referring to xml version, not html version. (see https://www.php.net/manual/en/class.domdocument.php_).

2) Added `$td->setAttribute('colspan', 1);`  to set colspan on td elements in table header.

I've tested this locally and it works.

