### PR TITLE
Feature/add university model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Below are a list of methods available in the `PIMAdapter` class
 | Name | Parameters | Description |
 | ---- | ---- | ---- |
 | `getAllPrograms` | N/A | List all Programs, no query parameters. |
+| `getUniversity` | N/A | Fetch University fields, no query parameters. |
 | `getCollegeList` | [Query](https://contentful.github.io/contentful.php/api/6.4.0/Contentful/Query.html) `$query` - optional | Lists all or some Colleges by Query. Use Query object to filter by specific id(s) |
 | `getLinkedBannerEntriesByEntryId` | string `$entry_id` | Fetches entries (Programs) linked to Banner entries by matching Banner entry Id (`$entry_id`/`sys.id`) |
 | `getProgramsByCollege` | string `$college_name`, [Query](https://contentful.github.io/contentful.php/api/6.4.0/Contentful/Query.html) `$query` - optional | This method walks backwards from the College Entry to the Banner Entry and finally to the linked Entries attached to the Banner Entry such as a Program Entry. Using the College Entry Id that's found when doing a lookup of Colleges by `$college_name`, we filter the API by `$college[0]['id']` with the ID of the fields.`college.sys.id` value in the Banner Entry. Finally, we get linked Entries belonging to the Banner entry. **This method will only return Program entries as Banner entries are only attached to Program Entries.** |

--- a/src/Helpers/mapEntriesToModel.php
+++ b/src/Helpers/mapEntriesToModel.php
@@ -3,6 +3,7 @@
 namespace Northeastern\PIMFIMAdapter\Helpers;
 
 // PIM
+use Northeastern\PIMFIMAdapter\PIM\Model\University;
 use Northeastern\PIMFIMAdapter\PIM\Model\College;
 use Northeastern\PIMFIMAdapter\PIM\Model\Program;
 
@@ -10,9 +11,14 @@ use Northeastern\PIMFIMAdapter\PIM\Model\Program;
 use Northeastern\PIMFIMAdapter\FIM\Model\Profile;
 
 function mapEntriesToModel($content_type, $entries) {
-    $entries_array = null;
+    $entries_array = [];
 
     switch ($content_type) {
+        case 'university':
+            $entries_array = collect($entries)->map(function($item) {
+                return (new University($item))->toArray();
+            });
+            break;
         case 'college':
             $entries_array = collect($entries)->map(function($item) {
                 return (new College($item))->toArray();

--- a/src/PIM/Model/University.php
+++ b/src/PIM/Model/University.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Northeastern\PIMFIMAdapter\PIM\Model;
+
+use Northeastern\PIMFIMAdapter\Concerns\RendersRichText;
+use Contentful\Delivery\Resource\Entry as ResourceEntry;
+use Northeastern\PIMFIMAdapter\Model\Entry;
+
+class University extends Entry {
+    use RendersRichText;
+
+    protected $name;
+    protected $curriculumDisclaimer;
+    protected $estimatedTotalTuitionDisclaimer;
+    protected $estimatedFeesDisclaimer;
+
+    public function __construct(ResourceEntry $item)
+    {
+        parent::__construct($item->getSystemProperties());
+        
+        $this->name = $item->name;
+        $this->curriculumDisclaimer = $this->renderRichTextNodes($item->curriculumDisclaimer);
+        $this->estimatedTotalTuitionDisclaimer = $this->renderRichTextNodes($item->estimatedTotalTuitionDisclaimer);
+        $this->estimatedFeesDisclaimer = $this->renderRichTextNodes($item->estimatedFeesDisclaimer);
+    }
+
+    public function toArray()
+    {
+        return [
+            ...parent::toArray(),
+
+            'name' => $this->name,
+            'curriculumDisclaimer' => $this->curriculumDisclaimer,
+            'estimatedTotalTuitionDisclaimer' => $this->estimatedTotalTuitionDisclaimer,
+            'estimatedFeesDisclaimer' => $this->estimatedFeesDisclaimer,
+        ];
+    }
+}

--- a/src/PIM/PIMAdapter.php
+++ b/src/PIM/PIMAdapter.php
@@ -17,6 +17,7 @@ class PIMAdapter extends Adapter {
 
     private $program_content_type = 'program';
     private $college_content_type = 'college';
+    private $university_content_type = 'university';
     private $banner_content_type = 'banner';
 
     public function __construct(
@@ -246,6 +247,22 @@ class PIMAdapter extends Adapter {
         $entries = getAllContentfulEntries($this->adapter, $this->college_content_type, $query);
 
         return $entries;
+    }
+
+    /**
+     * Get University Fields
+     * 
+     * Fetch University fields, no query parameters.
+     * 
+     * @return ResourceArray $university_fields_array
+     */
+    public function getUniversity(){
+        
+        $university_fields = $this->adapter->getEntriesByContentType( $this->university_content_type);
+
+        $university_fields_array = mapEntriesToModel($this->university_content_type, $university_fields);
+
+        return $university_fields_array;
     }
 
     /**


### PR DESCRIPTION
See [Issue 13](https://github.com/ITS-Digital-Technology/pim-fim-adapter/issues/13) for overview.

DETAILS

`src/PIM/Model/University.php` - Add a new model class called `University` to the PIM Adapter, and add the following fields to the `University` Model in the PIM Adapter: `name`, ~~`tuitionDisclaimer`~~`curriculumDisclaimer`, `estimatedTotalTuitionDisclaimer`, `estimatedFeesDisclaimer`.

`src/PIM/PIMAdapter.php` - In `PIMAdapter` Class, add new property/variable for `$university_content_type` and set value to `'university'` for use as `$this->university_content_type` throughout the Class. Create new helper method called `getUniversity` in `PIMAdapter` Class. Get Content from `university` content type in Contentful using `$this->adapter->getEntriesByContentType( $this->university_content_type);`. Wrap the method's response in a `mapEntriesToModel` to ensure the response is simplified for those pulling data from the University entry record in Contentful.

`src/Helpers/mapEntriesToModel.php` - Update `mapEntriesToModel` to include case for 'university' content type.

`README.md` - Update README to include new `getUniversity`  method.

I've tested this locally and it works.

