### PR TITLE
Add check for empty $thead_tr to transformDeadlinesToTable.php

### DIFF
--- a/src/PIM/Helpers/transformDeadlinesToTable.php
+++ b/src/PIM/Helpers/transformDeadlinesToTable.php
@@ -46,8 +46,9 @@ function transformDeadlinesToTable($deadline_json) {
         foreach ($deadline['headers'] as $thead_th) {
                 $td = $dom->createElement('td');
                 $td->setAttribute('colspan', 1);
-                $td = $thead_tr->appendChild($td);
-                
+                if (!empty($thead_tr)) {
+                    $td = $thead_tr->appendChild($td);
+                }
                 $th = $dom->createTextNode($thead_th);
                 $th = $td->appendChild($th);
         }


### PR DESCRIPTION
`src/PIM/Helpers/transformDeadlinesToTable.php` - Add a check for empty `$thead_tr` to avoid errors.

Tested locally and works.



