### PR TITLE
Add class to wrapper div around deadline table, to allow targeted styling

### DIFF
--- a/src/PIM/Helpers/transformDeadlinesToTable.php
+++ b/src/PIM/Helpers/transformDeadlinesToTable.php
@@ -16,6 +16,7 @@ function transformDeadlinesToTable($deadline_json) {
         // Root element
         $root = $dom->createElement('div');
         $root = $dom->appendChild($root);
+        $root->setAttribute('class', 'table-wrapper');
 
         // Heading
         $heading = $dom->createElement('h4', $deadline['key']);


### PR DESCRIPTION
Simpson Scarborough has asked that we add a class to the div wrapping the deadlines tables, to make it easier to add styles.

I've tested this locally and it works.

