### PR TITLE
Feature: Add Concentration HTML field to Banner Model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "files": [
             "src/Helpers/getAllContentfulEntries.php",
             "src/Helpers/mapEntriesToModel.php",
-            "src/PIM/Helpers/transformDeadlinesToTable.php"
+            "src/PIM/Helpers/transformDeadlinesToTable.php",
+            "src/PIM/Helpers/transformConcentrationsToHTML.php"
         ],
         "psr-4": {
             "Northeastern\\PIMFIMAdapter\\": "src"

--- a/src/PIM/Helpers/transformConcentrationsToHTML.php
+++ b/src/PIM/Helpers/transformConcentrationsToHTML.php
@@ -11,20 +11,30 @@ function transformConcentrationsToHTML($concentrations) {
         return;
     }
     
+    // Root element
+    $root = $dom->createElement('div');
+    $root = $dom->appendChild($root);
+    $root->setAttribute('class', 'concentrations-wrapper');
+
+    // Unordered List
+    $ul = $dom->createElement('ul');
+    $ul = $root->appendChild($ul);
+
     // Table Items/Values
     foreach ($concentrations as $concentration) {
-        // Root element
-        $root = $dom->createElement('div');
-        $root = $dom->appendChild($root);
-        $root->setAttribute('class', 'concentrations-wrapper');
+        // List Item
+        $li = $dom->createElement('li');
+        $li = $ul->appendChild($li);
 
-        // Heading
-        $heading = $dom->createElement('h4', $concentration['name']);
-        $heading = $root->appendChild($heading);
+        // Strong element for name
+        $name = $dom->createElement('strong', $concentration['name']);
+        $li->appendChild($name);
 
-        $description = $dom->createElement('p', $concentration['description']);
-        $description = $root->appendChild($description);
-
+        // Paragraph element for Description
+        if ($concentration['description']) {
+            $description = $dom->createElement('p', $concentration['description']);
+            $li->appendChild($description);
+        }
     }
 
     $html = $dom->saveHTML();

--- a/src/PIM/Helpers/transformConcentrationsToHTML.php
+++ b/src/PIM/Helpers/transformConcentrationsToHTML.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Northeastern\PIMFIMAdapter\PIM\Helpers;
+
+use DOMDocument;
+
+function transformConcentrationsToHTML($concentrations) {
+    $dom = new DOMDocument('1.0', 'utf-8');
+    
+    if (is_null($concentrations) || empty($concentrations) || !is_array($concentrations)) {
+        return;
+    }
+    
+    // Table Items/Values
+    foreach ($concentrations as $concentration) {
+        // Root element
+        $root = $dom->createElement('div');
+        $root = $dom->appendChild($root);
+        $root->setAttribute('class', 'concentrations-wrapper');
+
+        // Heading
+        $heading = $dom->createElement('h4', $concentration['name']);
+        $heading = $root->appendChild($heading);
+
+        $description = $dom->createElement('p', $concentration['description']);
+        $description = $root->appendChild($description);
+
+    }
+
+    $html = $dom->saveHTML();
+
+    return $html;
+}

--- a/src/PIM/Model/Banner.php
+++ b/src/PIM/Model/Banner.php
@@ -5,6 +5,8 @@ namespace Northeastern\PIMFIMAdapter\PIM\Model;
 use Contentful\Delivery\Resource\Entry as ResourceEntry;
 use Northeastern\PIMFIMAdapter\Model\Entry;
 
+use function Northeastern\PIMFIMAdapter\PIM\Helpers\transformConcentrationsToHTML;
+
 class Banner extends Entry {
     protected $bannerId;
     protected $friendlyName;
@@ -14,6 +16,7 @@ class Banner extends Entry {
     protected $college;
     protected $additionalColleges;
     protected $concentrations;
+    protected $concentrationsHTML;
 
     public function __construct(ResourceEntry $item)
     {
@@ -31,6 +34,7 @@ class Banner extends Entry {
         $this->concentrations = !is_null($item->concentrations) ? collect($item->concentrations)->map(function ($concentration) {
             return (new Concentration($concentration))->toArray();
         }) : null;
+        $this->concentrationsHTML = transformConcentrationsToHTML($item->concentrations);
     }
 
     public function toArray()
@@ -46,6 +50,7 @@ class Banner extends Entry {
             'college' => $this->college,
             'additionalColleges' => $this->additionalColleges,
             'concentrations' => $this->concentrations,
+            'concentrationsHTML' => $this->concentrationsHTML
         ];
     }
 }


### PR DESCRIPTION
Converts array of Concentration objects to HTML (unordered list for the wrapping element and for each concentration a list element with `<strong>` for headings/name and `<p>` for paragraph/description).