### PR TITLE
Update  getProgramsByCollege to use getAllContentfulEntries to avoid results getting truncated

### DIFF
--- a/src/PIM/PIMAdapter.php
+++ b/src/PIM/PIMAdapter.php
@@ -136,18 +136,9 @@ class PIMAdapter extends Adapter {
             })->collapse();
         })->collapse();
 
-        // Get Program entries by Array of Ids.
-        // Set higher than default query limit (100) if caller didn't set one, so results aren't truncted.
-        $params = method_exists($query, 'jsonSerialize') ? $query->jsonSerialize() : [];
-        if ( !array_key_exists('limit', $params) ) {
-            $query->setLimit(500);
-        }
-        $program_entries = $this->adapter->getEntriesByContentType(
-            $this->program_content_type,
-            $query->where('sys.id[in]', $program_ids->all())
-        );
+        // Get Program entries by Array of Ids (paged).
 
-        $programs = mapEntriesToModel($this->program_content_type, $program_entries);
+        $programs = getAllContentfulEntries($this->adapter, $this->program_content_type, $query->where('sys.id[in]', $program_ids->all()));
         
         return $programs;
     }


### PR DESCRIPTION
OVERVIEW

The current Contentful default query limit of 100 ends up truncating program results for colleges with more than 100 (such as CPS), when using `getProgramsByCollege`. We can udate that function to use `getAllContentfulEntries`, which will page through all results, and will not require raising the query limit.

DETAILS

`src/PIM/PIMAdapter.php` - Switch the `getProgramsByCollege` function from using `getEntriesByContentType` to `getAllContentfulEntries`, which will loop through all potential entries in a content type and avoid any truncation.


I've tested this locally and it works (I am now able to import the data for all 168 CPS programs).



