### PR TITLE
Release/1.0.15

### DIFF
--- a/src/PIM/PIMAdapter.php
+++ b/src/PIM/PIMAdapter.php
@@ -136,13 +136,9 @@ class PIMAdapter extends Adapter {
             })->collapse();
         })->collapse();
 
-        // Get Program entries by Array of Ids.
-        $program_entries = $this->adapter->getEntriesByContentType(
-            $this->program_content_type,
-            $query->where('sys.id[in]', $program_ids->all())
-        );
+        // Get Program entries by Array of Ids (paged).
 
-        $programs = mapEntriesToModel($this->program_content_type, $program_entries);
+        $programs = getAllContentfulEntries($this->adapter, $this->program_content_type, $query->where('sys.id[in]', $program_ids->all()));
         
         return $programs;
     }


### PR DESCRIPTION
OVERVIEW

When using `getProgramsByCollege`, the current Contentful default query limit of 100 ends up truncating program results for colleges with more than 100 programs (such as CPS), . We can update it to use `getAllContentfulEntries`, which will loop through all potential entries in a content type and avoid any truncation.

DETAILS

`src/PIM/PIMAdapter.php` - Switch `getProgramsByCollege` from using `getEntriesByContentType` to `getAllContentfulEntries`, which will loop through all potential entries in a content type and avoid any truncation.

I've tested this locally and it works (I am now able to import the data for all 168 CPS programs).



